### PR TITLE
fix(typo): fix blog link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ## 联系方式
 
 - GitHub: [LofiSu](https://github.com/LofiSu)
-- 博客地址: [酥酥的技术博客](www.lofisu.chat/)
+- 博客地址: [酥酥的技术博客](https://www.lofisu.chat/)
 
 > # Learning is a lifelong journey.
 


### PR DESCRIPTION
Use an exact domain without protocol prefix will cause unexpected behaviour in markdown. Markdown unable to auto detect links and this will make your markdown file be rendered as `https://github.com/LofiSu/myBlog/blob/main/www.lofisu.chat` but not `www.lofisu.chat` as expected.

Only a typo patch change.